### PR TITLE
refactor: remove inverse relationship logic from character relationships

### DIFF
--- a/lib/relationshipTypes.js
+++ b/lib/relationshipTypes.js
@@ -1,15 +1,18 @@
-// lib/relationshipTypes.js - Library defining character relationship types
-// This file defines various relationship types and their inverses for use in a character relationship management system
+// lib/relationshipTypes.js - Defines available character relationship types for Inkarus
 
 module.exports = [
-  { relation: 'sibling', inverse: 'sibling' },
-  { relation: 'friend', inverse: 'friend' },
-  { relation: 'mentor', inverse: 'apprentice' },
-  { relation: 'parent', inverse: 'child' },
-  { relation: 'lover', inverse: 'lover' },
-  { relation: 'enemy', inverse: 'enemy' },
-  { relation: 'rival', inverse: 'rival' },
-  { relation: 'admirer', inverse: 'idol' },
-  { relation: 'follower', inverse: 'leader' },
-  { relation: 'colleague', inverse: 'colleague' }
+  'sibling',
+  'friend',
+  'mentor',
+  'apprentice',
+  'parent',
+  'child',
+  'lover',
+  'enemy',
+  'rival',
+  'admirer',
+  'idol',
+  'follower',
+  'leader',
+  'colleague'
 ];

--- a/scripts/generate-relationships.js
+++ b/scripts/generate-relationships.js
@@ -3,16 +3,16 @@
 // Usage: node scripts/generate-relationships.js --project=<ID> [--count=10] [--verbose|-v]
 
 const sqlite3 = require('sqlite3').verbose();
-const path = require('path');
+const path    = require('path');
 const relationshipTypes = require('../lib/relationshipTypes');
 
 // Parse CLI arguments
-const args = process.argv.slice(2);
-const countArg = args.find(arg => arg.startsWith('--count='));
+const args       = process.argv.slice(2);
+const countArg   = args.find(arg => arg.startsWith('--count='));
 const projectArg = args.find(arg => arg.startsWith('--project='));
-const verbose = args.includes('--verbose') || args.includes('-v');
+const verbose    = args.includes('--verbose') || args.includes('-v');
 
-const count = countArg ? parseInt(countArg.split('=')[1], 10) : 5;
+const count     = countArg ? parseInt(countArg.split('=')[1], 10) : 5;
 const projectId = projectArg ? parseInt(projectArg.split('=')[1], 10) : null;
 
 if (!projectId || isNaN(projectId)) {
@@ -24,6 +24,7 @@ if (!projectId || isNaN(projectId)) {
 const db = new sqlite3.Database(path.resolve('db/database.sqlite'));
 
 db.serialize(() => {
+  // Fetch all characters for the given project
   db.all(
     `SELECT id, name FROM characters WHERE project_id = ?`,
     [projectId],
@@ -43,26 +44,27 @@ db.serialize(() => {
       let inserted = 0;
       const usedPairs = new Set();
 
-      const tryNext = () => {
+      // Attempt to insert relationships until count is reached
+      function tryNext() {
         if (inserted >= count) {
           console.log(`\n✅ Successfully inserted ${inserted} relationships into project ${projectId}.\n`);
           db.close();
           return;
         }
 
+        // Pick two distinct random characters
         const charA = characters[Math.floor(Math.random() * characters.length)];
         const charB = characters[Math.floor(Math.random() * characters.length)];
-
         if (charA.id === charB.id) return tryNext();
 
-        const pairKey = `${charA.id}-${charB.id}`;
-        const reverseKey = `${charB.id}-${charA.id}`;
-        if (usedPairs.has(pairKey) || usedPairs.has(reverseKey)) return tryNext();
+        const keyAB = `${charA.id}-${charB.id}`;
+        const keyBA = `${charB.id}-${charA.id}`;
+        if (usedPairs.has(keyAB) || usedPairs.has(keyBA)) return tryNext();
 
-        // Check if relationship already exists in DB
+        // Check if any relationship already exists in either direction
         db.get(
           `SELECT 1 FROM character_relationships 
-           WHERE (character_id = ? AND related_character_id = ?) 
+           WHERE (character_id = ? AND related_character_id = ?)
               OR (character_id = ? AND related_character_id = ?)`,
           [charA.id, charB.id, charB.id, charA.id],
           (checkErr, row) => {
@@ -70,56 +72,39 @@ db.serialize(() => {
               console.error('❌ Failed to check existing relationships:', checkErr.message);
               return tryNext();
             }
-
             if (row) {
-              usedPairs.add(pairKey);
-              return tryNext(); // Already exists
+              usedPairs.add(keyAB);
+              return tryNext();
             }
 
+            // Pick a random relationship type
             const rel = relationshipTypes[Math.floor(Math.random() * relationshipTypes.length)];
 
+            // Insert single-direction relationship only
             db.run(
-              `INSERT INTO character_relationships (character_id, related_character_id, relation) VALUES (?, ?, ?)`,
+              `INSERT INTO character_relationships (character_id, related_character_id, relation)
+               VALUES (?, ?, ?)`,
               [charA.id, charB.id, rel.relation],
-              function (err1) {
-                if (err1) {
-                  console.error('❌ Insert failed:', err1.message);
+              function (insertErr) {
+                if (insertErr) {
+                  console.error('❌ Insert failed:', insertErr.message);
                   return tryNext();
                 }
 
-                if (rel.inverse && rel.inverse !== rel.relation) {
-                  db.run(
-                    `INSERT INTO character_relationships (character_id, related_character_id, relation) VALUES (?, ?, ?)`,
-                    [charB.id, charA.id, rel.inverse],
-                    function (err2) {
-                      if (err2) {
-                        console.warn(`⚠️ Inserted only one-way relation: ${err2.message}`);
-                      }
-                      done();
-                    }
-                  );
-                } else {
-                  done();
+                if (verbose) {
+                  console.log(`🔗 ${charA.name} → ${rel.relation} → ${charB.name}`);
                 }
 
-                function done() {
-                  if (verbose) {
-                    console.log(`🔗 ${charA.name} → ${rel.relation} → ${charB.name}`);
-                    if (rel.inverse && rel.inverse !== rel.relation) {
-                      console.log(`🔁 ${charB.name} → ${rel.inverse} → ${charA.name}`);
-                    }
-                  }
-                  usedPairs.add(pairKey);
-                  inserted++;
-                  tryNext();
-                }
+                usedPairs.add(keyAB);
+                inserted++;
+                tryNext();
               }
             );
           }
         );
-      };
+      }
 
-      tryNext(); // Begin the loop
+      tryNext(); // Start generating relationships
     }
   );
 });


### PR DESCRIPTION
Completely removes support for inverse character relationships in Inkarus. The following changes are included:

- Dropped inverse_relation and description columns from the character_relationships table
- Removed unused logic from db/characterRelationships.js
- Updated relationship generation script to only create one-way links 
- Simplified relationshipTypes.js definitions
- Cleaned up related helper functions and usage references

This simplifies the character relationship system and avoids confusion or data duplication when modeling narrative connections.